### PR TITLE
AspNetCore 1.0 support

### DIFF
--- a/src/DataTables.AspNet.AspNetCore/Configuration.cs
+++ b/src/DataTables.AspNet.AspNetCore/Configuration.cs
@@ -25,11 +25,15 @@ THE SOFTWARE.
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using DataTables.AspNet.Core;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 using System.Linq;
+using System.Text;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Internal;
 
 namespace DataTables.AspNet.AspNetCore
 {
@@ -62,59 +66,48 @@ namespace DataTables.AspNet.AspNetCore
         /// Provides DataTables.AspNet registration for AspNet5 projects.
         /// </summary>
         /// <param name="services">Service collection for dependency injection.</param>
-        /// <param name="options">DataTables.AspNet options.</param>
-        public static void RegisterDataTables(this IServiceCollection services, IOptions options) { services.RegisterDataTables(options, new ModelBinder()); }
-
-        /// <summary>
-        /// Provides DataTables.AspNet registration for AspNet5 projects.
-        /// </summary>
-        /// <param name="services">Service collection for dependency injection.</param>
-        /// <param name="requestModelBinder">Request model binder to use when resolving 'IDataTablesRequest' models.</param>
-        public static void RegisterDataTables(this IServiceCollection services, ModelBinder requestModelBinder) { services.RegisterDataTables(new Options(), requestModelBinder); }
-
-        /// <summary>
-        /// Provides DataTables.AspNet registration for AspNet5 projects.
-        /// </summary>
-        /// <param name="services">Service collection for dependency injection.</param>
         /// <param name="parseRequestAdditionalParameters">Function to evaluante and parse aditional parameters sent within the request (user-defined parameters).</param>
         /// <param name="parseResponseAdditionalParameters">Indicates whether response aditional parameters parsing is enabled or not.</param>
-        public static void RegisterDataTables(this IServiceCollection services, Func<ModelBindingContext, IDictionary<string, object>> parseRequestAdditionalParameters, bool parseResponseAdditionalParameters) { services.RegisterDataTables(new Options(), new ModelBinder(), parseRequestAdditionalParameters, parseResponseAdditionalParameters); }
+        public static void RegisterDataTables(this IServiceCollection services, Func<ModelBindingContext, IDictionary<string, object>> parseRequestAdditionalParameters, bool parseResponseAdditionalParameters) { services.RegisterDataTables(new Options(), parseRequestAdditionalParameters, parseResponseAdditionalParameters); }
 
         /// <summary>
         /// Provides DataTables.AspNet registration for AspNet5 projects.
         /// </summary>
         /// <param name="options">DataTables.AspNet options.</param>
-        /// <param name="requestModelBinder">Model binder to use when resolving 'IDataTablesRequest' model.</param>
-        public static void RegisterDataTables(this IServiceCollection services, IOptions options, ModelBinder requestModelBinder) { services.RegisterDataTables(options, requestModelBinder, null, false); }
+        public static void RegisterDataTables(this IServiceCollection services, IOptions options) { services.RegisterDataTables(options, null, false); }
 
         /// <summary>
         /// Provides DataTables.AspNet registration for AspNet5 projects.
         /// </summary>
         /// <param name="services">Service collection for dependency injection.</param>
         /// <param name="options">DataTables.AspNet options.</param>
-        /// <param name="requestModelBinder">Request model binder to use when resolving 'IDataTablesRequest' models.</param>
         /// <param name="parseRequestAdditionalParameters">Function to evaluate and parse aditional parameters sent within the request (user-defined parameters).</param>
         /// <param name="enableResponseAdditionalParameters">Indicates whether response aditional parameters parsing is enabled or not.</param>
-        public static void RegisterDataTables(this IServiceCollection services, IOptions options, ModelBinder requestModelBinder, Func<ModelBindingContext, IDictionary<string, object>> parseRequestAdditionalParameters, bool enableResponseAdditionalParameters)
+        public static void RegisterDataTables(this IServiceCollection services, IOptions options, Func<ModelBindingContext, IDictionary<string, object>> parseRequestAdditionalParameters, bool enableResponseAdditionalParameters)
         {
-            if (options == null) throw new ArgumentNullException("options", "Options for DataTables.AspNet cannot be null.");
-            if (requestModelBinder == null) throw new ArgumentNullException("requestModelBinder", "Request model binder for DataTables.AspNet cannot be null.");
+            if (options == null) throw new ArgumentNullException(nameof(options), "Options for DataTables.AspNet cannot be null.");
 
             Options = options;
 
-            if (parseRequestAdditionalParameters != null)
+            services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(mvcOptions =>
             {
-                Options.EnableRequestAdditionalParameters();
-                requestModelBinder.ParseAdditionalParameters = parseRequestAdditionalParameters;
-            }
+                var readerFactory = services.BuildServiceProvider().GetRequiredService<IHttpRequestStreamReaderFactory>();
+                var formatter = mvcOptions.InputFormatters.Cast<JsonInputFormatter>().FirstOrDefault();
+                var modelBinder = new ModelBinder(formatter, readerFactory);
 
-            if (enableResponseAdditionalParameters)
-                Options.EnableResponseAdditionalParameters();
+                if (parseRequestAdditionalParameters != null)
+                {
+                    Options.EnableRequestAdditionalParameters();
+                    modelBinder.ParseAdditionalParameters = parseRequestAdditionalParameters;
+                }
 
-            services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(_options =>
-            {
-				// Should be inserted into first position because there is a generic binder which could end up resolving/binding model incorrectly.
-                _options.ModelBinderProviders.Insert(0, new ModelBinderProvider(requestModelBinder));
+                if (enableResponseAdditionalParameters)
+                    Options.EnableResponseAdditionalParameters();
+                
+                // Should be inserted into first position because there is a generic binder which could end up resolving/binding model incorrectly.
+                mvcOptions.ModelBinderProviders.Insert(0, new ModelBinderProvider(modelBinder, 
+                    mvcOptions.InputFormatters.Cast<JsonInputFormatter>().FirstOrDefault(),
+                    readerFactory));
             });
         }
 
@@ -122,18 +115,41 @@ namespace DataTables.AspNet.AspNetCore
         internal class ModelBinderProvider : IModelBinderProvider
         {
             public IModelBinder ModelBinder { get; private set; }
-            public ModelBinderProvider() { }
-            public ModelBinderProvider(IModelBinder modelBinder) { ModelBinder = modelBinder; }
+            private readonly JsonInputFormatter _formatter;
+            private readonly IHttpRequestStreamReaderFactory _readerFactory;
+
+            public ModelBinderProvider(ModelBinder binder, JsonInputFormatter formatter, IHttpRequestStreamReaderFactory readerFactory)
+            {
+                if (formatter == null)
+                {
+                    throw new ArgumentNullException(nameof(formatter));
+                }
+
+                if (readerFactory == null)
+                {
+                    throw new ArgumentNullException(nameof(readerFactory));
+                }
+
+                _formatter = formatter;
+                _readerFactory = readerFactory;
+                ModelBinder = binder;
+            }
+
             public IModelBinder GetBinder(ModelBinderProviderContext context)
             {
+                if (context == null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
                 if (IsBindable(context.Metadata.ModelType))
                 {
-                    if (ModelBinder == null) ModelBinder = new ModelBinder();
-                    return ModelBinder;
+                    return ModelBinder ?? (ModelBinder = new ModelBinder(_formatter, _readerFactory));
                 }
                 else return null;
             }
-            private bool IsBindable(Type type) { return type.Equals(typeof(DataTables.AspNet.Core.IDataTablesRequest)); }
+
+            private bool IsBindable(Type type) { return type == typeof(IDataTablesRequest); }
         }
     }
 }

--- a/src/DataTables.AspNet.AspNetCore/DataTables.AspNet.AspNetCore.xproj
+++ b/src/DataTables.AspNet.AspNetCore/DataTables.AspNet.AspNetCore.xproj
@@ -4,7 +4,7 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>a99e62ec-9fa2-4564-a4e1-92bdf40b9752</ProjectGuid>
     <RootNamespace>DataTables.AspNet.AspNetCore</RootNamespace>
@@ -17,5 +17,5 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/DataTables.AspNet.AspNetCore/DataTablesRequest.cs
+++ b/src/DataTables.AspNet.AspNetCore/DataTablesRequest.cs
@@ -35,21 +35,23 @@ namespace DataTables.AspNet.AspNetCore
     {
         public IDictionary<string, object> AdditionalParameters { get; private set; }
         public IEnumerable<Core.IColumn> Columns { get; private set; }
+        public IEnumerable<Core.ISort> Sortings { get; private set; }
         public int Draw { get; private set; }
         public int Length { get; private set; }
-        public Core.ISearch Search { get; private set; }
+        public Core.ISearch Search { get; private set; }        
         public int Start { get; private set; }
 
-        public DataTablesRequest(int draw, int start, int length, Core.ISearch search, IEnumerable<Core.IColumn> columns)
-            :this(draw, start, length, search, columns, null)
+        public DataTablesRequest(int draw, int start, int length, Core.ISearch search, IEnumerable<Core.IColumn> columns, IEnumerable<Core.ISort> sortings)
+            :this(draw, start, length, search, columns, sortings, null)
         { }
-        public DataTablesRequest(int draw, int start, int length, Core.ISearch search, IEnumerable<Core.IColumn> columns, IDictionary<string, object> additionalParameters)
+        public DataTablesRequest(int draw, int start, int length, Core.ISearch search, IEnumerable<Core.IColumn> columns, IEnumerable<Core.ISort> sortings, IDictionary<string, object> additionalParameters)
         {
             Draw = draw;
             Start = start;
             Length = length;
             Search = search;
             Columns = columns;
+            Sortings = sortings;
             AdditionalParameters = additionalParameters;
         }
     }

--- a/src/DataTables.AspNet.AspNetCore/ModelBinder.cs
+++ b/src/DataTables.AspNet.AspNetCore/ModelBinder.cs
@@ -25,11 +25,17 @@ THE SOFTWARE.
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using DataTables.AspNet.Core;
 using DataTables.AspNet.Core.NameConvention;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace DataTables.AspNet.AspNetCore
 {
@@ -38,6 +44,23 @@ namespace DataTables.AspNet.AspNetCore
     /// </summary>
     public class ModelBinder : IModelBinder
     {
+        private readonly JsonInputFormatter _formatter;
+        private readonly Func<Stream, Encoding, TextReader> _readerFactory;
+        public ModelBinder(JsonInputFormatter formatter, IHttpRequestStreamReaderFactory readerFactory)
+        {
+            if (formatter == null)
+            {
+                throw new ArgumentNullException(nameof(formatter));
+            }
+
+            if (readerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(readerFactory));
+            }
+
+            _formatter = formatter;
+            _readerFactory = readerFactory.CreateReader;
+        }
         /// <summary>
         /// Binds request data/parameters/values into a 'IDataTablesRequest' element.
         /// </summary>
@@ -45,93 +68,118 @@ namespace DataTables.AspNet.AspNetCore
         /// <returns>An IDataTablesRequest object or null if binding was not possible.</returns>
         public Task BindModelAsync(ModelBindingContext bindingContext)
         {
-            return Task.Factory.StartNew(() =>
+            //BindModel(
+            //       bindingContext,
+            //       DataTables.AspNet.AspNetCore.Configuration.Options,
+            //       ParseAdditionalParameters);
+
+            if (bindingContext == null)
             {
-                BindModel(
-                    bindingContext,
-                    DataTables.AspNet.AspNetCore.Configuration.Options,
-                    ParseAdditionalParameters);
-            });
-        }
-        /// <summary>
-        /// For internal and testing use only.
-        /// Binds request data/parameters/values into a 'IDataTablesRequest' element.
-        /// </summary>
-        /// <param name="controllerContext">Controller context for execution.</param>
-        /// <param name="bindingContext">Binding context for data/parameters/values.</param>
-        /// <param name="options">DataTables.AspNet global options.</param>
-        /// <returns>An IDataTablesRequest object or null if binding was not possible.</returns>
-        public virtual void BindModel(ModelBindingContext bindingContext, IOptions options, Func<ModelBindingContext, IDictionary<string, object>> parseAditionalParameters)
-        {
+                throw new ArgumentNullException(nameof(bindingContext));
+            }
+
             // Model binding is not set, thus AspNet5 will keep looking for other model binders.
-            if (!bindingContext.ModelType.Equals(typeof(Core.IDataTablesRequest)))
+            if (bindingContext.ModelType != typeof(IDataTablesRequest))
             {
                 //return ModelBindingResult.NoResult;
-                return;
+                return Task.FromResult(0);
             }
+
+            var options = Configuration.Options;
 
             // Binding is set to a null model to avoid unexpected errors.
             if (options == null || options.RequestNameConvention == null)
             {
                 //return ModelBindingResult.Failed(bindingContext.ModelName);
-                bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
-                return;
+                bindingContext.Result = ModelBindingResult.Failed(/*bindingContext.ModelName*/);
+                return Task.FromResult(0);
             }
 
-            var values = bindingContext.ValueProvider;
-
-            // Accordingly to DataTables docs, it is recommended to receive/return draw casted as int for security reasons.
-            // This is meant to help prevent XSS attacks.
-            var draw = values.GetValue(options.RequestNameConvention.Draw);
-            int _draw = 0;
-            if (options.IsDrawValidationEnabled && !Parse<Int32>(draw, out _draw))
+            // Special logic for body, treat the model name as string.Empty for the top level
+            // object, but allow an override via BinderModelName. The purpose of this is to try
+            // and be similar to the behavior for POCOs bound via traditional model binding.
+            string modelBindingKey;
+            if (bindingContext.IsTopLevelObject)
             {
-                //return ModelBindingResult.Failed(bindingContext.ModelName); // Null model result (invalid request).
-                bindingContext.Result = ModelBindingResult.Failed(bindingContext.ModelName);
-                return;
-            }
-
-            var start = values.GetValue(options.RequestNameConvention.Start);
-            int _start = 0;
-            Parse<int>(start, out _start);
-
-            var length = values.GetValue(options.RequestNameConvention.Length);
-            int _length = options.DefaultPageLength;
-            Parse<int>(length, out _length);
-
-            var searchValue = values.GetValue(options.RequestNameConvention.SearchValue);
-            string _searchValue = null;
-            Parse<string>(searchValue, out _searchValue);
-
-            var searchRegex = values.GetValue(options.RequestNameConvention.IsSearchRegex);
-            bool _searchRegex = false;
-            Parse<bool>(searchRegex, out _searchRegex);
-
-            var search = new Search(_searchValue, _searchRegex);
-
-            // Parse columns & column sorting.
-            var columns = ParseColumns(values, options.RequestNameConvention);
-            var sorting = ParseSorting(columns, values, options.RequestNameConvention);
-
-            if (options.IsRequestAdditionalParametersEnabled && parseAditionalParameters != null)
-            {
-                var aditionalParameters = parseAditionalParameters(bindingContext);
-                var model = new DataTablesRequest(_draw, _start, _length, search, columns, aditionalParameters);
-                {
-                    //return ModelBindingResult.Success(bindingContext.ModelName, model);
-                    bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, model);
-                    return;
-                }
+                modelBindingKey = bindingContext.BinderModelName ?? string.Empty;
             }
             else
             {
-                var model = new DataTablesRequest(_draw, _start, _length, search, columns);
+                modelBindingKey = bindingContext.ModelName;
+            }
+
+            try
+            {
+                JObject jsonModel;
+                var request = bindingContext.HttpContext.Request;
+                using (var streamReader = _readerFactory(request.Body, MediaType.GetEncoding(request.ContentType)))
                 {
-                    //return ModelBindingResult.Success(bindingContext.ModelName, model);
-                    bindingContext.Result = ModelBindingResult.Success(bindingContext.ModelName, model);
-                    return;
+                    using (var jsonReader = new JsonTextReader(streamReader))
+                    {
+                        jsonModel = (JObject)new JsonSerializer().Deserialize(jsonReader);
+                    }
+                }
+
+                // Accordingly to DataTables docs, it is recommended to receive/return draw casted as int for security reasons.
+                // This is meant to help prevent XSS attacks.
+                var draw = (int?)jsonModel[options.RequestNameConvention.Draw] ?? 0;
+                if (options.IsDrawValidationEnabled && draw == 0)
+                {
+                    bindingContext.Result = ModelBindingResult.Failed();
+                    return Task.FromResult(0);
+                }
+
+                var start = (int?)jsonModel[options.RequestNameConvention.Start] ?? 0;
+                var length = (int?)jsonModel[options.RequestNameConvention.Length] ?? options.DefaultPageLength;
+                var searchValue = (string)jsonModel[options.RequestNameConvention.SearchValue];
+                var searchRegex = (bool?)jsonModel[options.RequestNameConvention.IsSearchRegex] ?? false;
+                
+                var search = new Search(searchValue, searchRegex);
+
+                // Parse columns & column sorting.
+                var columns = ParseColumns(jsonModel, options.RequestNameConvention);
+                var sorting = ParseSorting(columns, jsonModel, options.RequestNameConvention);
+
+                if (options.IsRequestAdditionalParametersEnabled && ParseAdditionalParameters != null)
+                {
+                    var aditionalParameters = ParseAdditionalParameters(bindingContext);
+                    var model = new DataTablesRequest(draw, start, length, search, columns, sorting, aditionalParameters);
+                    {
+                        //return ModelBindingResult.Success(bindingContext.ModelName, model);
+                        bindingContext.Result = ModelBindingResult.Success(/*bindingContext.ModelName,*/ model);
+                        return Task.FromResult(0);
+                    }
+                }
+                else
+                {
+                    var model = new DataTablesRequest(draw, start, length, search, columns, sorting);
+                    {
+                        //return ModelBindingResult.Success(bindingContext.ModelName, model);
+                        bindingContext.Result = ModelBindingResult.Success(/*bindingContext.ModelName,*/ model);
+                        return Task.FromResult(0);
+                    }
                 }
             }
+            catch (Exception ex)
+            {
+                bindingContext.ModelState.AddModelError(modelBindingKey, ex, bindingContext.ModelMetadata);
+            }
+
+            return Task.FromResult(0);
+        }
+
+        /// <summary>
+        /// For internal and testing use only.
+        /// Binds request data/parameters/values into a 'IDataTablesRequest' element.
+        /// </summary>
+        /// <param name="bindingContext">Binding context for data/parameters/values.</param>
+        /// <param name="options">DataTables.AspNet global options.</param>
+        /// <param name="parseAditionalParameters"></param>
+        /// <returns>An IDataTablesRequest object or null if binding was not possible.</returns>
+        public virtual void BindModel(ModelBindingContext bindingContext, IOptions options, Func<ModelBindingContext, IDictionary<string, object>> parseAditionalParameters)
+        {
+            //using for test purpose only
+            //todo: call async method
         }
 
         /// <summary>
@@ -144,54 +192,35 @@ namespace DataTables.AspNet.AspNetCore
         /// For internal use only.
         /// Parse column collection.
         /// </summary>
-        /// <param name="values">Request parameters.</param>
+        /// <param name="jsonModel">Request parameters.</param>
         /// <param name="names">Name convention for request parameters.</param>
         /// <returns></returns>
-        private static IEnumerable<IColumn> ParseColumns(IValueProvider values, IRequestNameConvention names)
+        private static List<IColumn> ParseColumns(JObject jsonModel, IRequestNameConvention names)
         {
             var columns = new List<IColumn>();
 
-            int counter = 0;
+            var counter = 0;
             while (true)
             {
                 // Parses Field value.
-                var columnField = values.GetValue(String.Format(names.ColumnField, counter));
-                string _columnField = null;
-                if (!Parse<string>(columnField, out _columnField)) break;
-
+                var columnField = (string) jsonModel[string.Format(names.ColumnField, counter)];
+                if (columnField == null) break;
                 // Parses Name value.
-                var columnName = values.GetValue(String.Format(names.ColumnName, counter));
-                string _columnName = null;
-                if (!Parse<string>(columnName, out _columnName)) break;
-
+                var columnName = (string) jsonModel[string.Format(names.ColumnName, counter)];
+                if (columnName == null) break;
                 // Parses Orderable value.
-                var columnSortable = values.GetValue(String.Format(names.IsColumnSortable, counter));
-                bool _columnSortable = true;
-                Parse<bool>(columnSortable, out _columnSortable);
-
+                var columnSortable = (bool?) jsonModel[string.Format(names.IsColumnSortable, counter)] ?? true;
                 // Parses Searchable value.
-                var columnSearchable = values.GetValue(String.Format(names.IsColumnSearchable, counter));
-                bool _columnSearchable = true;
-                Parse<bool>(columnSearchable, out _columnSearchable);
-
+                var columnSearchable = (bool?) jsonModel[string.Format(names.IsColumnSearchable, counter)] ?? true;
                 // Parsed Search value.
-                var columnSearchValue = values.GetValue(String.Format(names.ColumnSearchValue, counter));
-                string _columnSearchValue = null;
-                Parse<string>(columnSearchValue, out _columnSearchValue);
-
+                var columnSearchValue = (string) jsonModel[string.Format(names.ColumnSearchValue, counter)];
                 // Parses IsRegex value.
-                var columnSearchRegex = values.GetValue(String.Format(names.IsColumnSearchRegex, counter));
-                bool _columnSearchRegex = false;
-                Parse<bool>(columnSearchRegex, out _columnSearchRegex);
-
-                var search = new Search(_columnSearchValue, _columnSearchRegex);
-
+                var columnSearchRegex = (bool?) jsonModel[string.Format(names.IsColumnSearchRegex, counter)] ?? false;
+                var search = new Search(columnSearchValue, columnSearchRegex);
                 // Instantiates a new column with parsed elements.
-                var column = new Column(_columnName, _columnField, _columnSearchable, _columnSortable, search);
-
+                var column = new Column(columnName, columnField, columnSearchable, columnSortable, search);
                 // Adds the column to the return collection.
                 columns.Add(column);
-
                 // Increments counter to keep processing columns.
                 counter++;
             }
@@ -204,52 +233,26 @@ namespace DataTables.AspNet.AspNetCore
         /// Parse sort collection.
         /// </summary>
         /// <param name="columns">Column collection to use when parsing sort.</param>
-        /// <param name="values">Request parameters.</param>
+        /// <param name="jsonModel">Request parameters.</param>
         /// <param name="names">Name convention for request parameters.</param>
         /// <returns></returns>
-        private static IEnumerable<ISort> ParseSorting(IEnumerable<IColumn> columns, IValueProvider values, IRequestNameConvention names)
+        private static List<ISort> ParseSorting(List<IColumn> columns, JObject jsonModel, IRequestNameConvention names)
         {
             var sorting = new List<ISort>();
 
-            for (int i = 0; i < columns.Count(); i++)
+            for (var i = 0; i < columns.Count; i++)
             {
-                var sortField = values.GetValue(String.Format(names.SortField, i));
-                int _sortField = 0;
-                if (!Parse<int>(sortField, out _sortField)) break;
+                var sortField = (int?) jsonModel[string.Format(names.SortField, i)];
+                if (sortField == null) break;
+                var column = columns.ElementAt((int) sortField);
 
-                var column = columns.ElementAt(_sortField);
+                var sortDirection = (string)jsonModel[string.Format(names.SortDirection, i)];
 
-                var sortDirection = values.GetValue(String.Format(names.SortDirection, i));
-                string _sortDirection = null;
-                Parse<string>(sortDirection, out _sortDirection);
-
-                if (column.SetSort(i, _sortDirection))
+                if (column.SetSort(i, sortDirection))
                     sorting.Add(column.Sort);
             }
 
             return sorting;
-        }
-
-        /// <summary>
-        /// Parses a possible raw value and transforms into a strongly-typed result.
-        /// </summary>
-        /// <typeparam name="ElementType">The expected type for result.</typeparam>
-        /// <param name="value">The possible request value.</param>
-        /// <param name="result">Returns the parsing result or default value for type is parsing failed.</param>
-        /// <returns>True if parsing succeeded, False otherwise.</returns>
-        private static bool Parse<ElementType>(ValueProviderResult value, out ElementType result)
-        {
-            result = default(ElementType);
-
-            if (value == null) return false;
-            if (string.IsNullOrWhiteSpace(value.FirstValue)) return false;
-
-            try
-            {
-                result = (ElementType)Convert.ChangeType(value.FirstValue, typeof(ElementType));
-                return true;
-            }
-            catch { return false; }
         }
     }
 }

--- a/src/DataTables.AspNet.AspNetCore/ModelBinder.cs
+++ b/src/DataTables.AspNet.AspNetCore/ModelBinder.cs
@@ -131,8 +131,8 @@ namespace DataTables.AspNet.AspNetCore
 
                 var start = (int?)jsonModel[options.RequestNameConvention.Start] ?? 0;
                 var length = (int?)jsonModel[options.RequestNameConvention.Length] ?? options.DefaultPageLength;
-                var searchValue = (string)jsonModel[options.RequestNameConvention.SearchValue];
-                var searchRegex = (bool?)jsonModel[options.RequestNameConvention.IsSearchRegex] ?? false;
+                var searchValue = (string)jsonModel.SelectToken(options.RequestNameConvention.SearchValue);
+                var searchRegex = (bool?)jsonModel.SelectToken(options.RequestNameConvention.IsSearchRegex) ?? false;
                 
                 var search = new Search(searchValue, searchRegex);
 
@@ -203,19 +203,19 @@ namespace DataTables.AspNet.AspNetCore
             while (true)
             {
                 // Parses Field value.
-                var columnField = (string) jsonModel[string.Format(names.ColumnField, counter)];
+                var columnField = (string) jsonModel.SelectToken(string.Format(names.ColumnField, counter));
                 if (columnField == null) break;
                 // Parses Name value.
-                var columnName = (string) jsonModel[string.Format(names.ColumnName, counter)];
+                var columnName = (string) jsonModel.SelectToken(string.Format(names.ColumnName, counter));
                 if (columnName == null) break;
                 // Parses Orderable value.
-                var columnSortable = (bool?) jsonModel[string.Format(names.IsColumnSortable, counter)] ?? true;
+                var columnSortable = (bool?) jsonModel.SelectToken(string.Format(names.IsColumnSortable, counter)) ?? true;
                 // Parses Searchable value.
-                var columnSearchable = (bool?) jsonModel[string.Format(names.IsColumnSearchable, counter)] ?? true;
+                var columnSearchable = (bool?) jsonModel.SelectToken(string.Format(names.IsColumnSearchable, counter)) ?? true;
                 // Parsed Search value.
-                var columnSearchValue = (string) jsonModel[string.Format(names.ColumnSearchValue, counter)];
+                var columnSearchValue = (string) jsonModel.SelectToken(string.Format(names.ColumnSearchValue, counter));
                 // Parses IsRegex value.
-                var columnSearchRegex = (bool?) jsonModel[string.Format(names.IsColumnSearchRegex, counter)] ?? false;
+                var columnSearchRegex = (bool?) jsonModel.SelectToken(string.Format(names.IsColumnSearchRegex, counter)) ?? false;
                 var search = new Search(columnSearchValue, columnSearchRegex);
                 // Instantiates a new column with parsed elements.
                 var column = new Column(columnName, columnField, columnSearchable, columnSortable, search);
@@ -242,11 +242,11 @@ namespace DataTables.AspNet.AspNetCore
 
             for (var i = 0; i < columns.Count; i++)
             {
-                var sortField = (int?) jsonModel[string.Format(names.SortField, i)];
+                var sortField = (int?) jsonModel.SelectToken(string.Format(names.SortField, i));
                 if (sortField == null) break;
                 var column = columns.ElementAt((int) sortField);
 
-                var sortDirection = (string)jsonModel[string.Format(names.SortDirection, i)];
+                var sortDirection = (string)jsonModel.SelectToken(string.Format(names.SortDirection, i));
 
                 if (column.SetSort(i, sortDirection))
                     sorting.Add(column.Sort);

--- a/src/DataTables.AspNet.AspNetCore/NameConvention/CamelCaseRequestNameConvention.cs
+++ b/src/DataTables.AspNet.AspNetCore/NameConvention/CamelCaseRequestNameConvention.cs
@@ -35,16 +35,16 @@ namespace DataTables.AspNet.AspNetCore.NameConvention
         public string Draw { get { return "draw"; } }
         public string Start { get { return "start"; } }
         public string Length { get { return "length"; } }
-        public string SearchValue { get { return "search[value]"; } }
-        public string IsSearchRegex { get { return "search[regex]"; } }
-        public string SortField { get { return "order[{0}][column]"; } }
-        public string SortDirection { get { return "order[{0}][dir]"; } }
-        public string ColumnField { get { return "columns[{0}][data]"; } }
-        public string ColumnName { get { return "columns[{0}][name]"; } }
-        public string IsColumnSearchable { get { return "columns[{0}][searchable]"; } }
-        public string IsColumnSortable { get { return "columns[{0}][orderable]"; } }
-        public string ColumnSearchValue { get { return "columns[{0}][search][value]"; } }
-        public string IsColumnSearchRegex { get { return "columns[{0}][search][regex]"; } }
+        public string SearchValue { get { return "search['value']"; } }
+        public string IsSearchRegex { get { return "search['regex']"; } }
+        public string SortField { get { return "order[{0}]['column']"; } }
+        public string SortDirection { get { return "order[{0}]['dir']"; } }
+        public string ColumnField { get { return "columns[{0}]['data']"; } }
+        public string ColumnName { get { return "columns[{0}]['name']"; } }
+        public string IsColumnSearchable { get { return "columns[{0}]['searchable']"; } }
+        public string IsColumnSortable { get { return "columns[{0}]['orderable']"; } }
+        public string ColumnSearchValue { get { return "columns[{0}]['search']['value']"; } }
+        public string IsColumnSearchRegex { get { return "columns[{0}]['search']['regex']"; } }
         public string SortAscending { get { return "asc"; } }
         public string SortDescending { get { return "desc"; } }
     }

--- a/src/DataTables.AspNet.AspNetCore/project.json
+++ b/src/DataTables.AspNet.AspNetCore/project.json
@@ -1,7 +1,7 @@
 ﻿{
     "id": "DataTables.AspNet.AspNetCore",
     "title": "DataTables.AspNet.AspNetCore",
-    "version": "2.0.0-beta3",
+    "version": "2.0.0-beta4",
     "description": "AspNetCore implementation for DataTables.AspNet.",
     "authors": [ "Anderson Matos" ],
 
@@ -9,7 +9,7 @@
         "summary": "AspNetCore implementation for DataTables.AspNet.",
         "tags": [ "DataTables", "DataTables.Mvc", "DataTables.AspNet", "AspNet", "AspNet5" ],
         "owners": [ "Anderson Matos" ],
-        "releaseNotes": "Finished porting to .NET Core RC2. Renamed from AspNet5 to AspNetCore.",
+        "releaseNotes": "AspNetCore 1.0 support",
         "iconUrl": "",
         "projectUrl": "https://github.com/ALMMa/datatables.aspnet",
         "licenseUrl": "",
@@ -22,20 +22,17 @@
     
     "language": "en-US",
     "copyright": "",
-    
-    "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
 
-        "DataTables.AspNet.Core": "2.0.0-beta3",
+  "dependencies": {
+    "Microsoft.AspNetCore.Mvc": "1.0.0",
 
-        "Newtonsoft.Json": "8.0.3"
-    },
+    "DataTables.AspNet.Core": "2.0.0-beta3",
+
+    "Newtonsoft.Json": "9.0.1"
+  },
 
     "frameworks": {
         "net451": { },
-        "netstandard1.5": {
-            "imports": "dnxcore50"
-        }
+        "netstandard1.6": {}
     }
 }


### PR DESCRIPTION
- I've added Aspnet Core 1.0 RTM support.
- The request parameter in actions must be prefixed with [FromBody], it reads json data from body of the request:
```csharp
        [HttpPost]
        public async Task<DataTablesJsonResult> GetPage([FromBody]IDataTablesRequest request)
        {
            //////
            var response = DataTablesResponse.Create(request, totalCount, filteredTotalCount, data);
            return new DataTablesJsonResult(response);
        }
```
- I've added the sortings to the `IDataTablesRequest` which was not present at the original version.